### PR TITLE
Add Lingui based i18n with language switch

### DIFF
--- a/components/appbar.tsx
+++ b/components/appbar.tsx
@@ -1,46 +1,63 @@
 import Link from 'next/link'
 import { useRouter } from 'next/router'
+import { useLingui, Trans } from '@lingui/react'
+import { locales } from '@/lib/i18n'
 
 const links = [
-	{ label: 'Story', href: '/story' },
-	{ label: 'Recipes', href: '/recipes' },
+        { id: 'Story', href: '/story' },
+        { id: 'Recipes', href: '/recipes' },
 ]
 
 const Appbar = () => {
-	const router = useRouter()
+        const router = useRouter()
+        const { i18n } = useLingui()
 
 	return (
 		<div className='fixed top-0 left-0 z-20 w-full bg-zinc-900 pt-safe'>
 			<header className='border-b bg-zinc-100 px-safe dark:border-zinc-800 dark:bg-zinc-900'>
 				<div className='mx-auto flex h-20 max-w-screen-md items-center justify-between px-6'>
-					<Link href='/'>
-						<h1 className='font-medium'>Rice Bowl</h1>
-					</Link>
+                                        <Link href='/'>
+                                                <h1 className='font-medium'>
+                                                        <Trans id='Rice Bowl' />
+                                                </h1>
+                                        </Link>
 
 					<nav className='flex items-center space-x-6'>
 						<div className='hidden sm:block'>
 							<div className='flex items-center space-x-6'>
-								{links.map(({ label, href }) => (
-									<Link
-										key={label}
-										href={href}
-										className={`text-sm ${
-											router.pathname === href
-												? 'text-indigo-500 dark:text-indigo-400'
-												: 'text-zinc-600 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-50'
-										}`}
-									>
-										{label}
-									</Link>
-								))}
-							</div>
-						</div>
+                                                                {links.map(({ id, href }) => (
+                                                                        <Link
+                                                                               key={id}
+                                                                               href={href}
+                                                                               className={`text-sm ${
+                                                                               router.pathname === href
+                                                                               ? 'text-indigo-500 dark:text-indigo-400'
+                                                                               : 'text-zinc-600 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-50'
+                                                                               }`}
+                                                                        >
+                                                                               <Trans id={id} />
+                                                                        </Link>
+                                                                ))}
+                                                        </div>
+                                                </div>
 
-						<div
-							title='Gluten Free'
-							className='h-10 w-10 rounded-full bg-zinc-200 bg-cover bg-center shadow-inner dark:bg-zinc-800'
-							style={{
-								backgroundImage:
+                                                <select
+                                                        value={router.locale}
+                                                        onChange={(e) => router.push(router.pathname, router.asPath, { locale: e.target.value })}
+                                                        className='rounded border bg-transparent p-1 text-sm dark:border-zinc-600'
+                                                >
+                                                        {Object.entries(locales).map(([loc, { label }]) => (
+                                                                <option key={loc} value={loc}>
+                                                                        {label}
+                                                                </option>
+                                                        ))}
+                                                </select>
+
+                                                <div
+                                                        title={i18n._('Gluten Free')}
+                                                        className='h-10 w-10 rounded-full bg-zinc-200 bg-cover bg-center shadow-inner dark:bg-zinc-800'
+                                                        style={{
+                                                                backgroundImage:
 									'url(https://images.unsplash.com/photo-1612480797665-c96d261eae09?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80)',
 							}}
 						/>

--- a/components/bottom-nav.tsx
+++ b/components/bottom-nav.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link'
 import { useRouter } from 'next/router'
+import { Trans } from '@lingui/react'
 
 const BottomNav = () => {
 	const router = useRouter()
@@ -8,22 +9,22 @@ const BottomNav = () => {
 		<div className='sm:hidden'>
 			<nav className='fixed bottom-0 w-full border-t bg-zinc-100 pb-safe dark:border-zinc-800 dark:bg-zinc-900'>
 				<div className='mx-auto flex h-16 max-w-md items-center justify-around px-6'>
-					{links.map(({ href, label, icon }) => (
-						<Link
-							key={label}
-							href={href}
-							className={`flex h-full w-full flex-col items-center justify-center space-y-1 ${
-								router.pathname === href
+                                        {links.map(({ href, id, icon }) => (
+                                                <Link
+                                                        key={id}
+                                                        href={href}
+                                                        className={`flex h-full w-full flex-col items-center justify-center space-y-1 ${
+                                                                router.pathname === href
 									? 'text-indigo-500 dark:text-indigo-400'
 									: 'text-zinc-600 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-50'
 							}`}
 						>
 							{icon}
-							<span className='text-xs text-zinc-600 dark:text-zinc-400'>
-								{label}
-							</span>
-						</Link>
-					))}
+                                                        <span className='text-xs text-zinc-600 dark:text-zinc-400'>
+                                                                <Trans id={id} />
+                                                        </span>
+                                                </Link>
+                                        ))}
 				</div>
 			</nav>
 		</div>
@@ -33,10 +34,10 @@ const BottomNav = () => {
 export default BottomNav
 
 const links = [
-	{
-		label: 'Home',
-		href: '/',
-		icon: (
+        {
+                id: 'Home',
+                href: '/',
+                icon: (
 			<svg
 				viewBox='0 0 15 15'
 				fill='none'
@@ -51,10 +52,10 @@ const links = [
 			</svg>
 		),
 	},
-	{
-		label: 'Story',
-		href: '/story',
-		icon: (
+        {
+                id: 'Story',
+                href: '/story',
+                icon: (
 			<svg
 				viewBox='0 0 15 15'
 				fill='none'
@@ -69,10 +70,10 @@ const links = [
 			</svg>
 		),
 	},
-	{
-		label: 'Recipes',
-		href: '/recipes',
-		icon: (
+        {
+                id: 'Recipes',
+                href: '/recipes',
+                icon: (
 			<svg
 				viewBox='0 0 15 15'
 				fill='none'

--- a/components/page.tsx
+++ b/components/page.tsx
@@ -1,19 +1,21 @@
 import Head from 'next/head'
 import Appbar from '@/components/appbar'
 import BottomNav from '@/components/bottom-nav'
+import { useLingui } from '@lingui/react'
 
 interface Props {
 	title?: string
 	children: React.ReactNode
 }
 
-const Page = ({ title, children }: Props) => (
-	<>
-		{title ? (
-			<Head>
-				<title>Rice Bowl | {title}</title>
-			</Head>
-		) : null}
+const Page = ({ title, children }: Props) => {
+        const { i18n } = useLingui()
+
+        return (
+                <>
+                        <Head>
+                                <title>{i18n._('Rice Bowl')}</title>
+                        </Head>
 
 		<Appbar />
 
@@ -27,8 +29,9 @@ const Page = ({ title, children }: Props) => (
 			<div className='p-6'>{children}</div>
 		</main>
 
-		<BottomNav />
-	</>
-)
+                <BottomNav />
+                </>
+        )
+}
 
 export default Page

--- a/lib/i18n.tsx
+++ b/lib/i18n.tsx
@@ -1,0 +1,30 @@
+import { i18n } from '@lingui/core'
+import { I18nProvider } from '@lingui/react'
+import { useRouter } from 'next/router'
+import { useEffect, useState } from 'react'
+
+export const locales = {
+  it: { label: 'IT', loader: () => import('@/locales/it/messages') },
+  en: { label: 'EN', loader: () => import('@/locales/en/messages') },
+}
+
+const defaultLocale = 'it'
+
+export const LocalizationProvider = ({ children }: { children: React.ReactNode }) => {
+  const { locale } = useRouter()
+  const [ready, setReady] = useState(false)
+
+  useEffect(() => {
+    const load = async () => {
+      const current = (locale || defaultLocale) as keyof typeof locales
+      const { default: messages } = await locales[current].loader()
+      i18n.load(current, messages)
+      i18n.activate(current)
+      setReady(true)
+    }
+    load()
+  }, [locale])
+
+  if (!ready) return null
+  return <I18nProvider i18n={i18n}>{children}</I18nProvider>
+}

--- a/locales/en/messages.ts
+++ b/locales/en/messages.ts
@@ -1,0 +1,19 @@
+export const messages = {
+  'Story': 'Story',
+  'Recipes': 'Recipes',
+  'Rice Bowl': 'Rice Bowl',
+  'Gluten Free': 'Gluten Free',
+  'Home': 'Home',
+  'We grow a lot of rice.': 'We grow a lot of rice.',
+  'You love rice, and so does the rest of the world. In the crop year 2008/2009, the milled rice production volume amounted to over <0>448 million tons</0> worldwide.': 'You love rice, and so does the rest of the world. In the crop year 2008/2009, the milled rice production volume amounted to over <0>448 million tons</0> worldwide.',
+  'Source': 'Source',
+  'Ingredients': 'Ingredients',
+  'Like any good recipe, we appreciate community offerings to cultivate a delicous dish.': 'Like any good recipe, we appreciate community offerings to cultivate a delicous dish.',
+  'Thanks to': 'Thanks to',
+  'for high quality images': 'for high quality images',
+  'for lovely icons': 'for lovely icons',
+  '"I confess that when this all started, you were like a picture out of focus to me. And it took time for my eyes to adjust to you, to make sense of you, to really recognize you."': '"I confess that when this all started, you were like a picture out of focus to me. And it took time for my eyes to adjust to you, to make sense of you, to really recognize you."',
+  'Vision': 'Vision',
+  ', a two sentence story': ', a two sentence story'
+}
+export default messages

--- a/locales/it/messages.ts
+++ b/locales/it/messages.ts
@@ -1,0 +1,19 @@
+export const messages = {
+  'Story': 'Storia',
+  'Recipes': 'Ricette',
+  'Rice Bowl': 'Ciotola di riso',
+  'Gluten Free': 'Senza glutine',
+  'Home': 'Home',
+  'We grow a lot of rice.': 'Coltiviamo molto riso.',
+  'You love rice, and so does the rest of the world. In the crop year 2008/2009, the milled rice production volume amounted to over <0>448 million tons</0> worldwide.': 'Ami il riso, come il resto del mondo. Nell\'anno agricolo 2008/2009, la produzione mondiale di riso lavorato ha superato le <0>448 milioni di tonnellate</0>.',
+  'Source': 'Sorgente',
+  'Ingredients': 'Ingredienti',
+  'Like any good recipe, we appreciate community offerings to cultivate a delicous dish.': 'Come in ogni buona ricetta, apprezziamo i contributi della comunit\u00e0 per preparare un piatto delizioso.',
+  'Thanks to': 'Grazie a',
+  'for high quality images': 'per le immagini di alta qualit\u00e0',
+  'for lovely icons': 'per le icone graziose',
+  '"I confess that when this all started, you were like a picture out of focus to me. And it took time for my eyes to adjust to you, to make sense of you, to really recognize you."': '"Confesso che quando tutto \u00e8 iniziato, eri come un\'immagine fuori fuoco per me. Ci \u00e8 voluto tempo perch\u00e9 i miei occhi si abituassero a te, per capire chi fossi, per riconoscerti davvero."',
+  'Vision': 'Visione',
+  ', a two sentence story': ', una storia di due frasi'
+}
+export default messages

--- a/next.config.js
+++ b/next.config.js
@@ -7,5 +7,9 @@ const withPWA = require('next-pwa')({
 })
 
 module.exports = withPWA({
-	reactStrictMode: true,
+        reactStrictMode: true,
+        i18n: {
+                locales: ['it', 'en'],
+                defaultLocale: 'it',
+        },
 })

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
 		"lint": "next lint"
 	},
 	"dependencies": {
+		"@lingui/core": "^5.3.2",
+		"@lingui/macro": "^5.3.2",
+		"@lingui/react": "^5.3.2",
 		"next": "14.1.1",
 		"next-pwa": "^5.6.0",
 		"next-themes": "^0.2.1",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,15 +1,18 @@
 import type { AppProps } from 'next/app'
 import { ThemeProvider } from 'next-themes'
 import '@/styles/globals.css'
+import { LocalizationProvider } from '@/lib/i18n'
 
 export default function App({ Component, pageProps }: AppProps) {
-	return (
-		<ThemeProvider
-			attribute='class'
-			defaultTheme='system'
-			disableTransitionOnChange
-		>
-			<Component {...pageProps} />
-		</ThemeProvider>
-	)
+        return (
+                <LocalizationProvider>
+                        <ThemeProvider
+                                attribute='class'
+                                defaultTheme='system'
+                                disableTransitionOnChange
+                        >
+                                <Component {...pageProps} />
+                        </ThemeProvider>
+                </LocalizationProvider>
+        )
 }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,32 +1,33 @@
 import Page from '@/components/page'
 import Section from '@/components/section'
+import { Trans } from '@lingui/react'
 
 const Index = () => (
 	<Page>
 		<Section>
-			<h2 className='text-xl font-semibold text-zinc-800 dark:text-zinc-200'>
-				We grow a lot of rice.
-			</h2>
+                        <h2 className='text-xl font-semibold text-zinc-800 dark:text-zinc-200'>
+                                <Trans id='We grow a lot of rice.' />
+                        </h2>
 
 			<div className='mt-2'>
-				<p className='text-zinc-600 dark:text-zinc-400'>
-					You love rice, and so does the rest of the world. In the crop year
-					2008/2009, the milled rice production volume amounted to over{' '}
-					<span className='font-medium text-zinc-900 dark:text-zinc-50'>
-						448 million tons
-					</span>{' '}
-					worldwide.
-				</p>
+                                <p className='text-zinc-600 dark:text-zinc-400'>
+                                        <Trans
+                                                id='You love rice, and so does the rest of the world. In the crop year 2008/2009, the milled rice production volume amounted to over <0>448 million tons</0> worldwide.'
+                                                components={[
+                                                        <span key='b' className='font-medium text-zinc-900 dark:text-zinc-50' />,
+                                                ]}
+                                        />
+                                </p>
 
 				<br />
 
 				<p className='text-sm text-zinc-600 dark:text-zinc-400'>
-					<a
-						href='https://github.com/mvllow/next-pwa-template'
-						className='underline'
-					>
-						Source
-					</a>
+                                        <a
+                                                href='https://github.com/mvllow/next-pwa-template'
+                                                className='underline'
+                                        >
+                                                <Trans id='Source' />
+                                        </a>
 				</p>
 			</div>
 		</Section>

--- a/pages/recipes.tsx
+++ b/pages/recipes.tsx
@@ -1,35 +1,39 @@
 import Page from '@/components/page'
 import Section from '@/components/section'
+import { Trans } from '@lingui/react'
 
 const Recipes = () => (
 	<Page>
 		<Section>
-			<h2 className='text-xl font-semibold'>Ingredients</h2>
+                        <h2 className='text-xl font-semibold'>
+                                <Trans id='Ingredients' />
+                        </h2>
 
 			<div className='mt-2'>
-				<p className='text-zinc-600 dark:text-zinc-400'>
-					Like any good recipe, we appreciate community offerings to cultivate a
-					delicous dish.
-				</p>
+                                <p className='text-zinc-600 dark:text-zinc-400'>
+                                        <Trans id='Like any good recipe, we appreciate community offerings to cultivate a delicous dish.' />
+                                </p>
 			</div>
 		</Section>
 
 		<Section>
-			<h3 className='font-medium'>Thanks to</h3>
+                        <h3 className='font-medium'>
+                                <Trans id='Thanks to' />
+                        </h3>
 
 			<ul className='list-disc space-y-2 px-6 py-2'>
 				<li className='text-sm text-zinc-600 dark:text-zinc-400'>
-					<a href='https://unsplash.com' className='underline'>
-						Unsplash
-					</a>{' '}
-					for high quality images
+                                        <a href='https://unsplash.com' className='underline'>
+                                                Unsplash
+                                        </a>{' '}
+                                        <Trans id='for high quality images' />
 				</li>
 
 				<li className='text-sm text-zinc-600 dark:text-zinc-400'>
-					<a href='https://teenyicons.com' className='underline'>
-						Teenyicons
-					</a>{' '}
-					for lovely icons
+                                        <a href='https://teenyicons.com' className='underline'>
+                                                Teenyicons
+                                        </a>{' '}
+                                        <Trans id='for lovely icons' />
 				</li>
 			</ul>
 		</Section>

--- a/pages/story.tsx
+++ b/pages/story.tsx
@@ -1,26 +1,29 @@
 import Page from '@/components/page'
 import Section from '@/components/section'
+import { Trans } from '@lingui/react'
 
 const Story = () => (
 	<Page>
 		<Section>
-			<h2 className='text-xl font-semibold'>Story</h2>
+                        <h2 className='text-xl font-semibold'>
+                                <Trans id='Story' />
+                        </h2>
 
 			<div className='mt-2'>
-				<p className='text-zinc-600 dark:text-zinc-400'>
-					&quot;I confess that when this all started, you were like a picture
-					out of focus to me. And it took time for my eyes to adjust to you, to
-					make sense of you, to really recognize you.&quot;
-				</p>
+                                <p className='text-zinc-600 dark:text-zinc-400'>
+                                        <Trans id="I confess that when this all started, you were like a picture out of focus to me. And it took time for my eyes to adjust to you, to make sense of you, to really recognize you." />
+                                </p>
 
 				<br />
 
-				<p className='text-sm text-zinc-600 dark:text-zinc-400'>
-					<a href='https://twosentencestories.com/vision' className='underline'>
-						Vision
-					</a>
-					, a two sentence story
-				</p>
+                                <p className='text-sm text-zinc-600 dark:text-zinc-400'>
+                                        <Trans
+                                                id='<0>Vision</0>, a two sentence story'
+                                                components={[
+                                                        <a key='v' href='https://twosentencestories.com/vision' className='underline' />,
+                                                ]}
+                                        />
+                                </p>
 			</div>
 		</Section>
 	</Page>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,15 @@ importers:
 
   .:
     dependencies:
+      '@lingui/core':
+        specifier: ^5.3.2
+        version: 5.3.2
+      '@lingui/macro':
+        specifier: ^5.3.2
+        version: 5.3.2(react@18.2.0)
+      '@lingui/react':
+        specifier: ^5.3.2
+        version: 5.3.2(react@18.2.0)
       next:
         specifier: 14.1.1
         version: 14.1.1(@babel/core@7.23.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -697,6 +706,52 @@ packages:
   '@jridgewell/trace-mapping@0.3.19':
     resolution: {integrity: sha512-kf37QtfW+Hwx/buWGMPcR60iF9ziHa6r/CZJIHbmcm4+0qrXiVdxegAH0F6yddEVQ7zdkjcGCgCzUu+BcbhQxw==}
 
+  '@lingui/core@5.3.2':
+    resolution: {integrity: sha512-rLtpZvs5RYlebwjb047PldmiuFBbbVOhEofA90N8pgTCIlfnJRTxfevd6gx3Qp0/uG+AV0DWcZxtba6H/MPYug==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@lingui/babel-plugin-lingui-macro': 5.3.2
+      babel-plugin-macros: 2 || 3
+    peerDependenciesMeta:
+      '@lingui/babel-plugin-lingui-macro':
+        optional: true
+      babel-plugin-macros:
+        optional: true
+
+  '@lingui/macro@5.3.2':
+    resolution: {integrity: sha512-K+G24xhbWFaYVxJRz+I8qXUISfXJ+T9BN+b9RMR+0pwsIshK4TWJNti8WiG8cnPxQmMeQ2waZqCJUPVObGbGvw==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@lingui/babel-plugin-lingui-macro': 5.3.2
+      babel-plugin-macros: 2 || 3
+    peerDependenciesMeta:
+      '@lingui/babel-plugin-lingui-macro':
+        optional: true
+      babel-plugin-macros:
+        optional: true
+
+  '@lingui/message-utils@5.3.2':
+    resolution: {integrity: sha512-YUBrXApa3kxcL9oimJdw7oiAJ2ESkI24uyTMaRp9XYNaWgWqpEgoxC5bDN2Fwnk5THFjUp/l64kAD5LJGQhJxQ==}
+    engines: {node: '>=20.0.0'}
+    bundledDependencies:
+      - '@messageformat/date-skeleton'
+
+  '@lingui/react@5.3.2':
+    resolution: {integrity: sha512-wKvgVIKmlz4pIu+mlixjKDLXJoqyG3N3WPB76EScNuDMN0L9T1xMA/bjO9SxgEaUypflALHRsTA2rzViskLFHg==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@lingui/babel-plugin-lingui-macro': 5.3.2
+      babel-plugin-macros: 2 || 3
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@lingui/babel-plugin-lingui-macro':
+        optional: true
+      babel-plugin-macros:
+        optional: true
+
+  '@messageformat/parser@5.1.1':
+    resolution: {integrity: sha512-3p0YRGCcTUCYvBKLIxtDDyrJ0YijGIwrTRu1DT8gIviIDZru8H23+FkY6MJBzM1n9n20CiM4VeDYuBsrrwnLjg==}
+
   '@next/env@14.1.1':
     resolution: {integrity: sha512-7CnQyD5G8shHxQIIg3c7/pSeYFeMhsNbpU/bmvH7ZnDql7mNRgg8O2JZrhrc/soFnfBnKP4/xXNiiSIPn2w8gA==}
 
@@ -932,6 +987,7 @@ packages:
 
   acorn-import-assertions@1.9.0:
     resolution: {integrity: sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==}
+    deprecated: package has been renamed to acorn-import-attributes
     peerDependencies:
       acorn: ^8
 
@@ -1786,6 +1842,9 @@ packages:
     resolution: {integrity: sha512-3TV69ZbrvV6U5DfQimop50jE9Dl6J8O1ja1dvBbMba/sZ3YBEQqJ2VZRoQPVnhlzjNtU1vaXRZVrVjU4qtm8yA==}
     hasBin: true
 
+  js-sha256@0.10.1:
+    resolution: {integrity: sha512-5obBtsz9301ULlsgggLg542s/jqtddfOpV5KJc4hajc9JV8GeY2gZHSVpYBn4nWqAUTJ9v+xwtbJ1mIBgIH5Vw==}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -1938,6 +1997,9 @@ packages:
 
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  moo@0.5.2:
+    resolution: {integrity: sha512-iSAJLHYKnX41mKcJKjqvnAN9sf0LMDTXDEvFv+ffuRR9a1MIuXLjMNL6EsnDHSkKLTWNqQQ5uo61P4EbU4NU+Q==}
 
   ms@2.1.2:
     resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
@@ -2623,6 +2685,9 @@ packages:
   universalify@2.0.0:
     resolution: {integrity: sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==}
     engines: {node: '>= 10.0.0'}
+
+  unraw@3.0.0:
+    resolution: {integrity: sha512-08/DA66UF65OlpUDIQtbJyrqTR0jTAlJ+jsnkQ4jxR7+K5g5YG1APZKQSMCE1vqqmD+2pv6+IdEjmopFatacvg==}
 
   upath@1.2.0:
     resolution: {integrity: sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==}
@@ -3531,6 +3596,34 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.1
       '@jridgewell/sourcemap-codec': 1.4.15
 
+  '@lingui/core@5.3.2':
+    dependencies:
+      '@babel/runtime': 7.23.1
+      '@lingui/message-utils': 5.3.2
+      unraw: 3.0.0
+
+  '@lingui/macro@5.3.2(react@18.2.0)':
+    dependencies:
+      '@lingui/core': 5.3.2
+      '@lingui/react': 5.3.2(react@18.2.0)
+    transitivePeerDependencies:
+      - react
+
+  '@lingui/message-utils@5.3.2':
+    dependencies:
+      '@messageformat/parser': 5.1.1
+      js-sha256: 0.10.1
+
+  '@lingui/react@5.3.2(react@18.2.0)':
+    dependencies:
+      '@babel/runtime': 7.23.1
+      '@lingui/core': 5.3.2
+      react: 18.2.0
+
+  '@messageformat/parser@5.1.1':
+    dependencies:
+      moo: 0.5.2
+
   '@next/env@14.1.1': {}
 
   '@next/eslint-plugin-next@13.5.4':
@@ -4264,7 +4357,7 @@ snapshots:
       debug: 4.3.4
       enhanced-resolve: 5.15.0
       eslint: 8.51.0
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.7.5(eslint@8.51.0)(typescript@5.2.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.7.5(eslint@8.51.0)(typescript@5.2.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.28.1(eslint@8.51.0))(eslint@8.51.0))(eslint@8.51.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.7.5(eslint@8.51.0)(typescript@5.2.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.51.0)
       eslint-plugin-import: 2.28.1(@typescript-eslint/parser@6.7.5(eslint@8.51.0)(typescript@5.2.2))(eslint-import-resolver-typescript@3.6.1)(eslint@8.51.0)
       fast-glob: 3.3.1
       get-tsconfig: 4.7.2
@@ -4276,7 +4369,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.8.0(@typescript-eslint/parser@6.7.5(eslint@8.51.0)(typescript@5.2.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.7.5(eslint@8.51.0)(typescript@5.2.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.28.1(eslint@8.51.0))(eslint@8.51.0))(eslint@8.51.0):
+  eslint-module-utils@2.8.0(@typescript-eslint/parser@6.7.5(eslint@8.51.0)(typescript@5.2.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.51.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -4297,7 +4390,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.51.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.7.5(eslint@8.51.0)(typescript@5.2.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.7.5(eslint@8.51.0)(typescript@5.2.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.28.1(eslint@8.51.0))(eslint@8.51.0))(eslint@8.51.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.7.5(eslint@8.51.0)(typescript@5.2.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.51.0)
       has: 1.0.4
       is-core-module: 2.13.0
       is-glob: 4.0.3
@@ -4799,6 +4892,8 @@ snapshots:
 
   jiti@1.20.0: {}
 
+  js-sha256@0.10.1: {}
+
   js-tokens@4.0.0: {}
 
   js-yaml@4.1.0:
@@ -4931,6 +5026,8 @@ snapshots:
       brace-expansion: 2.0.1
 
   minimist@1.2.8: {}
+
+  moo@0.5.2: {}
 
   ms@2.1.2: {}
 
@@ -5596,6 +5693,8 @@ snapshots:
       crypto-random-string: 2.0.0
 
   universalify@2.0.0: {}
+
+  unraw@3.0.0: {}
 
   upath@1.2.0: {}
 


### PR DESCRIPTION
## Summary
- integrate `@lingui` packages and configure Next.js i18n
- add `LocalizationProvider` for language loading
- insert language toggle in the app bar
- replace hardcoded text with `<Trans>` messages
- provide Italian and English message catalogs

## Testing
- `npx tsc --noEmit`
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_685bd787a5b4832f98840255e365d9fb