### PR TITLE
Implement avatar selector and persistent profile data

### DIFF
--- a/components/avatar.tsx
+++ b/components/avatar.tsx
@@ -1,0 +1,96 @@
+import React from 'react'
+
+export type AvatarType = 'cat' | 'dog'
+
+interface Props {
+  type: AvatarType
+  animate?: boolean
+}
+
+export const Avatar: React.FC<Props> = ({ type, animate }) => {
+  if (type === 'dog') return <Dog animate={animate} />
+  return <Cat animate={animate} />
+}
+
+const Cat: React.FC<{ animate?: boolean }> = ({ animate }) => (
+  <div className={`cat${animate ? '' : ' no-animation'}`}>
+    <div className='head'>
+      <div className='ears'>
+        <div className='ear left'></div>
+        <div className='ear right'></div>
+      </div>
+      <div className='eyes'>
+        <div className='eye left'></div>
+        <div className='eye right'></div>
+      </div>
+      <div className='muzzle'>
+        <div className='nose'></div>
+      </div>
+    </div>
+    <div className='body'>
+      <div className='paw'></div>
+    </div>
+    <div className='tail'>
+      <div className='tail-segment'>
+        <div className='tail-segment'>
+          <div className='tail-segment'>
+            <div className='tail-segment'>
+              <div className='tail-segment'>
+                <div className='tail-segment'>
+                  <div className='tail-segment'>
+                    <div className='tail-segment'>
+                      <div className='tail-segment'>
+                        <div className='tail-segment'>
+                          <div className='tail-segment'>
+                            <div className='tail-segment'>
+                              <div className='tail-segment'>
+                                <div className='tail-segment'></div>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+)
+
+const Dog: React.FC<{ animate?: boolean }> = ({ animate }) => (
+  <div className={`box${animate ? '' : ' no-animation'}`}>
+    <div className='head'>
+      <div className='ear ear-left'>
+        <div className='inner-ear inner-ear-left'></div>
+      </div>
+      <div className='ear ear-right'>
+        <div className='inner-ear inner-ear-right'></div>
+      </div>
+      <div className='face face-left'>
+        <div className='dot dot-1'></div>
+        <div className='dot dot-2'></div>
+        <div className='dot dot-3'></div>
+      </div>
+      <div className='face face-mid'></div>
+      <div className='face face-right'>
+        <div className='dot dot-1'></div>
+        <div className='dot dot-2'></div>
+        <div className='dot dot-3'></div>
+      </div>
+      <div className='eye eye-left'></div>
+      <div className='eye eye-right'></div>
+      <div className='nose'>
+        <div className='dot'></div>
+      </div>
+      <div className='mounth'></div>
+      <div className='tongue'></div>
+    </div>
+  </div>
+)
+
+export default Avatar

--- a/components/profile-menu.tsx
+++ b/components/profile-menu.tsx
@@ -1,21 +1,47 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import Link from 'next/link'
 import { useLingui, Trans } from '@lingui/react'
 import LanguageToggle from '@/components/language-toggle'
 import ThemeToggle from '@/components/theme-toggle'
+import Avatar, { AvatarType } from '@/components/avatar'
 
 const iconClass = 'mr-2 h-4 w-4 opacity-70 group-hover:opacity-100'
 
 const ProfileMenu = () => {
   const [open, setOpen] = useState(false)
-  const [loggedIn, setLoggedIn] = useState(false)
+  const [user, setUser] = useState<{ avatar: AvatarType; color: string } | null>(null)
   const { i18n } = useLingui()
 
-  const toggle = () => setOpen((o) => !o)
+  const toggle = () => {
+    if (!open) {
+      const token = localStorage.getItem('token')
+      if (token) {
+        fetch('/api/user/me', { headers: { Authorization: `Bearer ${token}` } })
+          .then((r) => (r.ok ? r.json() : null))
+          .then((data) => {
+            if (data) setUser({ avatar: data.avatar as AvatarType, color: data.color })
+          })
+      } else {
+        setUser(null)
+      }
+    }
+    setOpen((o) => !o)
+  }
   const logout = () => {
-    setLoggedIn(false)
+    localStorage.removeItem('token')
+    setUser(null)
     setOpen(false)
   }
+
+  useEffect(() => {
+    const token = localStorage.getItem('token')
+    if (!token) return
+    fetch('/api/user/me', { headers: { Authorization: `Bearer ${token}` } })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => {
+        if (data) setUser({ avatar: data.avatar as AvatarType, color: data.color })
+      })
+  }, [])
 
 
   return (
@@ -23,23 +49,23 @@ const ProfileMenu = () => {
       <button
         onClick={toggle}
         className={`relative h-10 w-10 overflow-hidden rounded-full border border-zinc-300 dark:border-zinc-700 ${
-          loggedIn ? '' : 'bg-zinc-400'
+          user ? '' : 'bg-zinc-400'
         }`}
         aria-label={i18n._('My profile')}
       >
-        {loggedIn && (
-          <img
-            src='https://images.unsplash.com/photo-1612480797665-c96d261eae09?auto=format&fit=facearea&facepad=2&w=256&h=256&q=80'
-            alt=''
-            className='h-full w-full object-cover'
-          />
+        {user && (
+          <div className='h-full w-full flex items-center justify-center' style={{ backgroundColor: user.color }}>
+            <div className='scale-50'>
+              <Avatar type={user.avatar} />
+            </div>
+          </div>
         )}
       </button>
 
       {open && (
         <div className='absolute right-0 mt-2 w-48 rounded-lg bg-white p-2 shadow-lg dark:bg-zinc-800 z-[250]'>
           <ul className='text-sm text-zinc-600 dark:text-zinc-300'>
-            {loggedIn ? (
+            {user ? (
               <>
                 <li>
                   <Link href='/profile' className='group flex items-center rounded px-2 py-1 hover:text-indigo-500'>
@@ -47,7 +73,7 @@ const ProfileMenu = () => {
                       <path d='M5 20a7 7 0 1114 0H5z' stroke='currentColor' />
                       <circle cx='12' cy='7' r='3' stroke='currentColor' />
                     </svg>
-                    <Trans id='My profile' />
+                    <Trans id='My page' />
                   </Link>
                 </li>
                 <li>

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -2,6 +2,7 @@ import type { AppProps } from 'next/app'
 import { ThemeProvider } from 'next-themes'
 import '@/styles/globals.css'
 import '@/styles/login.css'
+import '@/styles/avatars.css'
 import { LocalizationProvider } from '@/lib/i18n'
 
 export default function App({ Component, pageProps }: AppProps) {

--- a/pages/api/auth/register.ts
+++ b/pages/api/auth/register.ts
@@ -8,7 +8,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return res.status(405).end('Method Not Allowed')
   }
 
-  const { email, password } = req.body as { email?: string; password?: string }
+  const { email, password, name } = req.body as { email?: string; password?: string; name?: string }
 
   if (!email || !password) {
     return res.status(400).json({ error: 'Missing fields' })
@@ -16,7 +16,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
   try {
     const hashed = await bcrypt.hash(password, 10)
-    const user = await prisma.user.create({ data: { email, password: hashed } })
+    const color = `hsl(${Math.floor(Math.random() * 360)},70%,50%)`
+    const user = await prisma.user.create({ data: { email, password: hashed, name, avatar: 'cat', color } })
     return res.status(201).json({ success: true, user: { id: user.id, email: user.email } })
   } catch (err: any) {
     return res.status(400).json({ error: err.message })

--- a/pages/api/user/change-password.ts
+++ b/pages/api/user/change-password.ts
@@ -1,0 +1,30 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import jwt from 'jsonwebtoken'
+import bcrypt from 'bcryptjs'
+import prisma from '@/lib/prisma'
+
+const secret = process.env.JWT_SECRET || 'secret'
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST')
+    return res.status(405).end('Method Not Allowed')
+  }
+  const auth = req.headers.authorization
+  if (!auth) return res.status(401).json({ error: 'Unauthorized' })
+  const token = auth.split(' ')[1]
+  try {
+    const payload = jwt.verify(token, secret) as { sub: string }
+    const { oldPassword, newPassword } = req.body as { oldPassword?: string; newPassword?: string }
+    if (!oldPassword || !newPassword) return res.status(400).json({ error: 'Missing fields' })
+    const user = await prisma.user.findUnique({ where: { id: payload.sub } })
+    if (!user) return res.status(401).json({ error: 'Unauthorized' })
+    const valid = await bcrypt.compare(oldPassword, user.password)
+    if (!valid) return res.status(401).json({ error: 'Invalid credentials' })
+    const hashed = await bcrypt.hash(newPassword, 10)
+    await prisma.user.update({ where: { id: payload.sub }, data: { password: hashed } })
+    return res.status(200).json({ success: true })
+  } catch (err: any) {
+    return res.status(400).json({ error: err.message })
+  }
+}

--- a/pages/api/user/me.ts
+++ b/pages/api/user/me.ts
@@ -1,0 +1,20 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import jwt from 'jsonwebtoken'
+import prisma from '@/lib/prisma'
+
+const secret = process.env.JWT_SECRET || 'secret'
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const auth = req.headers.authorization
+  if (!auth) return res.status(401).json({ error: 'Unauthorized' })
+  const token = auth.split(' ')[1]
+  try {
+    const payload = jwt.verify(token, secret) as { sub: string }
+    const user = await prisma.user.findUnique({ where: { id: payload.sub } })
+    if (!user) return res.status(401).json({ error: 'Unauthorized' })
+    const { password, ...data } = user
+    return res.status(200).json(data)
+  } catch {
+    return res.status(401).json({ error: 'Unauthorized' })
+  }
+}

--- a/pages/api/user/update.ts
+++ b/pages/api/user/update.ts
@@ -1,0 +1,31 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import jwt from 'jsonwebtoken'
+import prisma from '@/lib/prisma'
+
+const secret = process.env.JWT_SECRET || 'secret'
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST')
+    return res.status(405).end('Method Not Allowed')
+  }
+  const auth = req.headers.authorization
+  if (!auth) return res.status(401).json({ error: 'Unauthorized' })
+  const token = auth.split(' ')[1]
+  try {
+    const payload = jwt.verify(token, secret) as { sub: string }
+    const { name, description, avatar, color } = req.body as {
+      name?: string
+      description?: string
+      avatar?: string
+      color?: string
+    }
+    await prisma.user.update({
+      where: { id: payload.sub },
+      data: { name, description, avatar, color },
+    })
+    return res.status(200).json({ success: true })
+  } catch (err: any) {
+    return res.status(400).json({ error: err.message })
+  }
+}

--- a/pages/profile.tsx
+++ b/pages/profile.tsx
@@ -1,15 +1,39 @@
+import { useEffect, useState } from 'react'
 import Page from '@/components/page'
-import Section from '@/components/section'
-import { Trans } from '@lingui/react'
+import Avatar, { AvatarType } from '@/components/avatar'
 
-const Profile = () => (
-  <Page title='Profile'>
-    <Section>
-      <h2 className='text-xl font-semibold'>
-        <Trans id='My profile' />
-      </h2>
-    </Section>
-  </Page>
-)
+interface ProfileData {
+  email: string
+  name: string | null
+  description: string | null
+  avatar: AvatarType
+  color: string
+}
 
-export default Profile
+export default function Profile() {
+  const [data, setData] = useState<ProfileData | null>(null)
+  useEffect(() => {
+    const token = localStorage.getItem('token')
+    if (!token) return
+    fetch('/api/user/me', { headers: { Authorization: `Bearer ${token}` } })
+      .then((r) => r.json())
+      .then(setData)
+  }, [])
+
+  if (!data) return <Page title='Profile'></Page>
+
+  return (
+    <Page title='Profile'>
+      <div className='p-4 flex flex-col items-center space-y-4'>
+        <div className='h-24 w-24 rounded-full flex items-center justify-center' style={{ backgroundColor: data.color }}>
+          <Avatar type={data.avatar} />
+        </div>
+        <div className='text-center'>
+          <h2 className='text-xl font-semibold'>{data.name || ''}</h2>
+          <p className='text-sm text-zinc-600'>{data.email}</p>
+          <p className='mt-2'>{data.description}</p>
+        </div>
+      </div>
+    </Page>
+  )
+}

--- a/pages/profile/edit.tsx
+++ b/pages/profile/edit.tsx
@@ -1,0 +1,101 @@
+import { useEffect, useState } from 'react'
+import Page from '@/components/page'
+import Avatar, { AvatarType } from '@/components/avatar'
+import { useRouter } from 'next/router'
+
+interface Profile {
+  email: string
+  name: string | null
+  description: string | null
+  avatar: AvatarType
+  color: string
+}
+
+export default function EditProfile() {
+  const [profile, setProfile] = useState<Profile | null>(null)
+  const [name, setName] = useState('')
+  const [description, setDescription] = useState('')
+  const [avatar, setAvatar] = useState<AvatarType>('cat')
+  const router = useRouter()
+  const token = typeof window !== 'undefined' ? localStorage.getItem('token') : null
+
+  useEffect(() => {
+    if (!token) return
+    fetch('/api/user/me', { headers: { Authorization: `Bearer ${token}` } })
+      .then((r) => r.json())
+      .then((data) => {
+        setProfile(data)
+        setName(data.name || '')
+        setDescription(data.description || '')
+        setAvatar(data.avatar as AvatarType)
+      })
+  }, [token])
+
+  const saveProfile = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!token) return
+    await fetch('/api/user/update', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+      body: JSON.stringify({ name, description, avatar })
+    })
+    router.push('/profile')
+  }
+
+  const changePassword = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    if (!token) return
+    const form = e.currentTarget
+    const oldPassword = (form.elements.namedItem('old') as HTMLInputElement).value
+    const newPassword = (form.elements.namedItem('new') as HTMLInputElement).value
+    await fetch('/api/user/change-password', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+      body: JSON.stringify({ oldPassword, newPassword })
+    })
+    form.reset()
+  }
+
+  if (!profile) return <Page title='Profile'></Page>
+
+  return (
+    <Page title='Profile'>
+      <div className='max-w-xl mx-auto space-y-6 p-4'>
+        <form onSubmit={saveProfile} className='space-y-4'>
+          <div className='flex justify-center'>
+            <div className='h-24 w-24 rounded-full overflow-hidden flex items-center justify-center' style={{ backgroundColor: profile.color }}>
+              <Avatar type={avatar} />
+            </div>
+          </div>
+          <div className='flex space-x-4 justify-center'>
+            <label>
+              <input type='radio' name='avatar' value='cat' checked={avatar==='cat'} onChange={()=>setAvatar('cat')} /> Cat
+            </label>
+            <label>
+              <input type='radio' name='avatar' value='dog' checked={avatar==='dog'} onChange={()=>setAvatar('dog')} /> Dog
+            </label>
+          </div>
+          <div>
+            <label className='block text-sm'>Name</label>
+            <input className='w-full border p-2' value={name} onChange={(e)=>setName(e.target.value)} />
+          </div>
+          <div>
+            <label className='block text-sm'>Email</label>
+            <input className='w-full border p-2 bg-zinc-100' value={profile.email} readOnly />
+          </div>
+          <div>
+            <label className='block text-sm'>Description</label>
+            <textarea className='w-full border p-2' value={description} onChange={(e)=>setDescription(e.target.value)} />
+          </div>
+          <button type='submit' className='px-4 py-2 bg-indigo-500 text-white rounded'>Save</button>
+        </form>
+        <form onSubmit={changePassword} className='space-y-2'>
+          <h3 className='text-lg font-medium'>Change password</h3>
+          <input type='password' name='old' placeholder='Old password' className='w-full border p-2' />
+          <input type='password' name='new' placeholder='New password' className='w-full border p-2' />
+          <button type='submit' className='px-4 py-2 bg-indigo-500 text-white rounded'>Change</button>
+        </form>
+      </div>
+    </Page>
+  )
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -14,4 +14,8 @@ model User {
   email     String   @unique
   password  String
   createdAt DateTime @default(now())
+  name       String?
+  description String?
+  avatar     String   @default("cat")
+  color      String
 }

--- a/styles/avatars.css
+++ b/styles/avatars.css
@@ -1,0 +1,199 @@
+/* Avatar styles */
+
+.no-animation * {
+  animation: none !important;
+}
+
+/* Cat avatar */
+#box {
+  display: block;
+  height: 100%;
+  width: 100%;
+}
+.cat * {
+  text-align: center;
+  margin-left: auto;
+  margin-right: auto;
+}
+.cat, .ears, .eyes, .muzzle, .body, .paw, .tail, .tail-segment {position: relative;}
+.head, .body, .paw, .tail-segment {background-color: #000000;}
+.left {float: left;}
+.right {float: right;}
+.cat {
+  margin-top: 50px;
+  animation: purr 5s 2 cubic-bezier(0,.75,1,.25);
+}
+.head {
+  width: 100px;
+  height: 90px;
+  border-radius: 50%;
+  z-index: 100;
+  animation: head-bob 5s 2 ease-in-out;
+}
+.ears {
+  top: -20px;
+  z-index: -100;
+}
+.ear {
+  width: 0;
+  height: 0;
+  border-left: 25px solid transparent;
+  border-right: 25px solid transparent;
+  border-bottom: 50px solid #000000;
+}
+.ear.left {
+  transform: rotate(-20deg) translateX(-10px);
+}
+.ear.right {
+  transform: rotate(20deg) translateX(10px);
+}
+.eyes {
+  top: -18px;
+  width: 60%;
+}
+.eye {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background-color: #FFD700;
+  animation: eye-blink 5s 2;
+  text-align: center;
+}
+
+.muzzle {
+  top: 50px;
+}
+.nose {
+  width: 0;
+  height: 0;
+  border-left: 10px solid transparent;
+  border-right: 10px solid transparent;
+  border-top: 10px solid #666666;
+}
+.body {
+  width: 200px;
+  height: 120px;
+  border-top-left-radius: 200px;
+  border-top-right-radius: 200px;
+  top: -75px;
+  left: 90px;
+  z-index: -10;
+}
+.paw {
+  height: 30px;
+  width: 50px;
+  border-radius: 25px;
+  left: -100px;
+  top: 90px;
+}
+.tail {
+  left: 180px;
+  top: -100px;
+  transform: rotate(90deg);
+  }
+
+.tail-segment {
+  height: 20px;
+  width: 30px;
+  border-radius: 25px;
+  top: 0px;
+  left: 10px;
+  animation: tail-swish 5s 2 cubic-bezier(.8,0,.2,1);
+}
+
+@keyframes tail-swish {
+  0% {transform: rotate(12deg);}
+  10% {transform: rotate(12deg);}
+  40% {transform: rotate(-5deg);}
+  50% {transform: rotate(5deg);}
+  60% {transform: rotate(-5deg);}
+  100% {transform: rotate(12deg);}
+}
+
+@keyframes head-bob {
+  0% {transform: translateX(-15px) translateY(45px);}
+  10% {transform: translateX(-15px) translateY(45px);}
+  30% {transform: translateX(0) translateY(0);}
+  75% {transform: translateX(0) translateY(0);}
+  90% {transform: translateX(-15px) translateY(45px);}
+  100% {transform: translateX(-15px) translateY(45px);}
+}
+
+@keyframes eye-blink {
+  0% {transform: scaleY(0);}
+  10% {transform: scaleY(0);}
+  15% {transform: scaleY(1);}
+  48% {transform: scaleY(1);}
+  50% {transform: scaleY(0);}
+  52% {transform: scaleY(1);}
+  90% {transform: scaleY(1);}
+  95% {transform: scaleY(0);} 
+  100% {transform: scaleY(0);}  
+}
+
+@keyframes purr {
+  0% {left: -1px;}
+  1% {left: 0px;}
+  2% {left: -1px;}
+  3% {left: 0px;}
+  4% {left: -1px;}
+  5% {left: 0px;}
+  6% {left: -1px;}
+  7% {left: 0px;}
+  8% {left: -1px;}
+  9% {left: 0px;}
+  10% {left: -1px;}
+  11% {left: 0px;}
+  12% {left: -1px;}
+  13% {left: 0px;}
+  14% {left: -1px;}
+  15% {left: 0px;}
+  16% {left: -1px;}
+  17% {left: 0px;}
+  18% {left: -1px;}
+  19% {left: 0px;}
+  20% {left: -1px;}
+  21% {left: 0px;}
+  94% {left: 0px;}
+  95% {left: -1px;}
+  96% {left: 0px;}
+  97% {left: -1px;}
+  98% {left: 0px;}
+  99% {left: -1px;}
+  100% {left: 0px;}
+}
+
+/* Dog avatar */
+.box {
+  position: relative;
+  display: block;
+  margin: auto;
+  width: 400px;
+  height: 280px;
+}
+.head { position:absolute; top:16.5%; left:25%; width:50%; height:67%; border-radius:50%; }
+.ear { position:absolute; background:#b3b3b3; border-radius:50%; z-index:1; }
+.ear-left { width:43%; height:63%; top:3%; left:-2%; border-radius:60% 60% 15% 15%/85% 85% 15% 15%; background:#e0e0e0; transform:rotate(35deg); }
+.ear-right { width:43%; height:63%; top:3%; right:-2%; border-radius:60% 60% 15% 15%/85% 85% 15% 15%; background:#e0e0e0; transform:rotate(-35deg); }
+.inner-ear { position:absolute; border-radius:60% 60% 15% 15%/85% 85% 15% 15%; width:70%; height:80%; top:15%; background:#b3b3b3; }
+.inner-ear-left { left:5%; }
+.inner-ear-right { right:5%; }
+.face { position:absolute; background:#e0e0e0; border-radius:50%; z-index:3; }
+.face-left { width:50%; height:72%; top:16%; left:6%; }
+.face-mid { width:68%; height:72%; top:-7%; left:17%; }
+.face-right{ width:50%; height:72%; top:15%; right:4%; }
+.dot { position:absolute; border-radius:50%; background:#27354a; }
+.face-left .dot-1{ width:3%; height:3%; top:78%; left:66%; }
+.face-left .dot-2{ width:3%; height:3%; top:83%; left:60%; }
+.face-left .dot-3{ width:3%; height:3%; top:83%; left:70%; }
+.face-right .dot-1{ width:3%; height:3%; top:78%; right:66%; }
+.face-right .dot-2{ width:3%; height:3%; top:83%; right:60%; }
+.face-right .dot-3{ width:3%; height:3%; top:83%; right:70%; }
+.eye { position:absolute; background:#27354a; height:14.5%; width:9.5%; border-radius:50%; z-index:4; }
+.eye-left { top:20%; left:55%; }
+.eye-right{ top:20%; right:55%; }
+.nose{ position:absolute; background:#27354a; width:21%; height:15.5%; left:40%; top:55%; border-radius:36px; z-index:5; }
+.nose .dot{ position:absolute; background:#808080; width:21%; height:15.5%; left:30%; top:22%; border-radius:36px; }
+.mounth{ position:absolute; border-bottom:50px solid #e0e0e0; border-radius:70px; left:33%; top:60%; width:36%; height:33.5%; z-index:1; }
+.tongue{ position:absolute; border-bottom:50px solid #ff8087; border-radius:74px; left:43%; top:36%; width:16%; height:49.5%; z-index:1; animation:tongue 2s 2; }
+@keyframes tongue { 0% {top:40%;} 50% {top:42%;} 100% {top:36%;} }


### PR DESCRIPTION
## Summary
- expand user schema with name, description, avatar and color
- return profile info through new API routes
- add update and password change APIs
- assign random avatar color during registration
- show avatar and color in profile menu and replace login text with *My page*
- implement profile page and editing form with avatar selector
- provide CSS avatars (cat and dog)

## Testing
- `npm run build` *(fails: prisma not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869130d6540832f8e805337c7811b6e