### PR TITLE
Handle missing JWT secret gracefully

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
 DATABASE_URL="your-vercel-postgres-connection-string"
+# Set a secret used for signing JWT tokens. If not provided, "secret" will be used.
 JWT_SECRET="your-jwt-secret"

--- a/pages/api/admin/send-message.ts
+++ b/pages/api/admin/send-message.ts
@@ -2,6 +2,8 @@ import { NextApiRequest, NextApiResponse } from 'next'
 import jwt from 'jsonwebtoken'
 import { prisma } from '@/lib/prisma'
 
+const secret = process.env.JWT_SECRET || 'secret'
+
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'POST') {
     return res.status(405).json({ error: 'Method not allowed' })
@@ -14,7 +16,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       return res.status(401).json({ error: 'Token mancante' })
     }
 
-    const decoded = jwt.verify(token, process.env.JWT_SECRET!) as { sub: string }
+    const decoded = jwt.verify(token, secret) as { sub: string }
     
     // Check if user is admin
     const user = await prisma.user.findUnique({

--- a/pages/api/admin/users.ts
+++ b/pages/api/admin/users.ts
@@ -2,6 +2,8 @@ import { NextApiRequest, NextApiResponse } from 'next'
 import jwt from 'jsonwebtoken'
 import { prisma } from '@/lib/prisma'
 
+const secret = process.env.JWT_SECRET || 'secret'
+
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'GET') {
     return res.status(405).json({ error: 'Method not allowed' })
@@ -14,7 +16,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       return res.status(401).json({ error: 'Token mancante' })
     }
 
-    const decoded = jwt.verify(token, process.env.JWT_SECRET!) as { sub: string }
+    const decoded = jwt.verify(token, secret) as { sub: string }
     
     // Check if user is admin
     const user = await prisma.user.findUnique({

--- a/pages/api/diary/dates.ts
+++ b/pages/api/diary/dates.ts
@@ -2,6 +2,8 @@ import { NextApiRequest, NextApiResponse } from 'next'
 import jwt from 'jsonwebtoken'
 import { prisma } from '@/lib/prisma'
 
+const secret = process.env.JWT_SECRET || 'secret'
+
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'GET') {
     return res.status(405).json({ error: 'Method not allowed' })
@@ -14,7 +16,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       return res.status(401).json({ error: 'Token mancante' })
     }
 
-    const decoded = jwt.verify(token, process.env.JWT_SECRET!) as { sub: string }
+    const decoded = jwt.verify(token, secret) as { sub: string }
     
     const entries = await prisma.diaryEntry.findMany({
       where: { userId: decoded.sub },

--- a/pages/api/diary/entry.ts
+++ b/pages/api/diary/entry.ts
@@ -2,6 +2,8 @@ import { NextApiRequest, NextApiResponse } from 'next'
 import jwt from 'jsonwebtoken'
 import { prisma } from '@/lib/prisma'
 
+const secret = process.env.JWT_SECRET || 'secret'
+
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'GET') {
     return res.status(405).json({ error: 'Method not allowed' })
@@ -14,7 +16,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       return res.status(401).json({ error: 'Token mancante' })
     }
 
-    const decoded = jwt.verify(token, process.env.JWT_SECRET!) as { sub: string }
+    const decoded = jwt.verify(token, secret) as { sub: string }
     const { date } = req.query
 
     if (!date || typeof date !== 'string') {

--- a/pages/api/diary/save.ts
+++ b/pages/api/diary/save.ts
@@ -2,6 +2,8 @@ import { NextApiRequest, NextApiResponse } from 'next'
 import jwt from 'jsonwebtoken'
 import { prisma } from '@/lib/prisma'
 
+const secret = process.env.JWT_SECRET || 'secret'
+
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   console.log('📥 API Save called:', { method: req.method, body: req.body })
   
@@ -18,7 +20,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       return res.status(401).json({ error: 'Token mancante' })
     }
 
-    const decoded = jwt.verify(token, process.env.JWT_SECRET!) as { sub: string }
+    const decoded = jwt.verify(token, secret) as { sub: string }
     console.log('👤 Token decoded:', { userId: decoded.sub })
     
     const { date, freeText, mood } = req.body

--- a/pages/api/messages/[id]/read.ts
+++ b/pages/api/messages/[id]/read.ts
@@ -2,6 +2,8 @@ import { NextApiRequest, NextApiResponse } from 'next'
 import jwt from 'jsonwebtoken'
 import { prisma } from '@/lib/prisma'
 
+const secret = process.env.JWT_SECRET || 'secret'
+
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'PATCH') {
     return res.status(405).json({ error: 'Method not allowed' })
@@ -14,7 +16,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       return res.status(401).json({ error: 'Token mancante' })
     }
 
-    const decoded = jwt.verify(token, process.env.JWT_SECRET!) as { sub: string }
+    const decoded = jwt.verify(token, secret) as { sub: string }
     const { id } = req.query
 
     if (!id || typeof id !== 'string') {

--- a/pages/api/messages/index.ts
+++ b/pages/api/messages/index.ts
@@ -2,6 +2,8 @@ import { NextApiRequest, NextApiResponse } from 'next'
 import jwt from 'jsonwebtoken'
 import { prisma } from '@/lib/prisma'
 
+const secret = process.env.JWT_SECRET || 'secret'
+
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'GET') {
     return res.status(405).json({ error: 'Method not allowed' })
@@ -14,7 +16,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       return res.status(401).json({ error: 'Token mancante' })
     }
 
-    const decoded = jwt.verify(token, process.env.JWT_SECRET!) as { sub: string }
+    const decoded = jwt.verify(token, secret) as { sub: string }
 
     const messages = await prisma.message.findMany({
       where: {

--- a/pages/api/user/update-email.ts
+++ b/pages/api/user/update-email.ts
@@ -2,6 +2,8 @@ import { NextApiRequest, NextApiResponse } from 'next'
 import jwt from 'jsonwebtoken'
 import { prisma } from '@/lib/prisma'
 
+const secret = process.env.JWT_SECRET || 'secret'
+
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'POST') {
     return res.status(405).json({ error: 'Method not allowed' })
@@ -14,7 +16,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       return res.status(401).json({ error: 'Token mancante' })
     }
 
-    const decoded = jwt.verify(token, process.env.JWT_SECRET!) as { sub: string }
+    const decoded = jwt.verify(token, secret) as { sub: string }
     const { email } = req.body
 
     if (!email || !email.includes('@')) {

--- a/pages/api/user/update-password.ts
+++ b/pages/api/user/update-password.ts
@@ -3,6 +3,8 @@ import jwt from 'jsonwebtoken'
 import bcrypt from 'bcryptjs'
 import { prisma } from '@/lib/prisma'
 
+const secret = process.env.JWT_SECRET || 'secret'
+
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'POST') {
     return res.status(405).json({ error: 'Method not allowed' })
@@ -15,7 +17,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       return res.status(401).json({ error: 'Token mancante' })
     }
 
-    const decoded = jwt.verify(token, process.env.JWT_SECRET!) as { sub: string }
+    const decoded = jwt.verify(token, secret) as { sub: string }
     const { currentPassword, newPassword, confirmPassword } = req.body
 
     if (!currentPassword || !newPassword || !confirmPassword) {

--- a/pages/api/user/update-phone.ts
+++ b/pages/api/user/update-phone.ts
@@ -2,6 +2,8 @@ import { NextApiRequest, NextApiResponse } from 'next'
 import jwt from 'jsonwebtoken'
 import { prisma } from '@/lib/prisma'
 
+const secret = process.env.JWT_SECRET || 'secret'
+
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'POST') {
     return res.status(405).json({ error: 'Method not allowed' })
@@ -14,7 +16,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       return res.status(401).json({ error: 'Token mancante' })
     }
 
-    const decoded = jwt.verify(token, process.env.JWT_SECRET!) as { sub: string }
+    const decoded = jwt.verify(token, secret) as { sub: string }
     const { phone } = req.body
 
     if (!phone || phone.trim() === '') {

--- a/readme.md
+++ b/readme.md
@@ -74,4 +74,4 @@ Fluffless doesn't mean "start with nothing". The goal of this template is to be 
    npm run dev
    ```
 
-Create a `.env` file from `.env.example` and provide your Vercel Postgres connection string and a JWT secret before running the commands.
+Create a `.env` file from `.env.example` and provide your Vercel Postgres connection string and a `JWT_SECRET` value before running the commands. If `JWT_SECRET` is not set, a default value of `"secret"` will be used during development.


### PR DESCRIPTION
## Summary
- use a default JWT secret when `JWT_SECRET` is undefined across API routes
- mention fallback secret in docs
- update env example

## Testing
- `npm install` *(fails: 403 from binaries.prisma.sh)*

------
https://chatgpt.com/codex/tasks/task_e_688548c405d8832f8b54ce2837b3b804