### PR TITLE
Add psychological vocabulary section

### DIFF
--- a/components/profile-menu.tsx
+++ b/components/profile-menu.tsx
@@ -79,6 +79,14 @@ const ProfileMenu = () => {
                       <Trans id='Admin Panel' />
                     </Link>
                   </li>
+                  <li>
+                    <Link href='/admin/create-dictionary' className='group flex items-center rounded px-2 py-1 hover:text-indigo-500'>
+                      <svg viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg' className={iconClass}>
+                        <path d='M12 4v16m8-8H4' stroke='currentColor'/>
+                      </svg>
+                      <Trans id='Create Dictionary' />
+                    </Link>
+                  </li>
                 )}
                 <li>
                   <button onClick={handleLogout} className='group flex w-full items-center rounded px-2 py-1 hover:text-indigo-500'>

--- a/locales/en/messages.ts
+++ b/locales/en/messages.ts
@@ -188,6 +188,18 @@ export const messages = {
   'Angry': 'Angry',
   'Fear': 'Fear',
   'Surprise': 'Surprise',
-  'Disgust': 'Disgust'
+  'Disgust': 'Disgust',
+  'Vocabolario Psicologico': 'Psychological Vocabulary',
+  'A glossary of relevant psychological terms': 'A glossary of relevant psychological terms',
+  'Create Dictionary': 'Create Dictionary',
+  'Create dictionary entry': 'Create dictionary entry',
+  'Word': 'Word',
+  'Definition': 'Definition',
+  'Saved': 'Saved',
+  'Please provide term and definition': 'Please provide term and definition',
+  'Access denied': 'Access denied',
+  'Search': 'Search',
+  'Saving...': 'Saving...',
+  'Save': 'Save'
 }
 export default messages

--- a/locales/it/messages.ts
+++ b/locales/it/messages.ts
@@ -187,6 +187,18 @@ export const messages = {
   'Fear': 'Paura',
   'Surprise': 'Sorpresa',
   'Disgust': 'Disgusto',
+  'Vocabolario Psicologico': 'Vocabolario Psicologico',
+  'A glossary of relevant psychological terms': 'Un glossario di termini rilevanti in ambito psicologico',
+  'Create Dictionary': 'Crea dizionario',
+  'Create dictionary entry': 'Crea voce dizionario',
+  'Word': 'Parola',
+  'Definition': 'Definizione',
+  'Saved': 'Salvato',
+  'Please provide term and definition': 'Inserisci termine e definizione',
+  'Access denied': 'Accesso negato',
+  'Search': 'Cerca',
+  'Saving...': 'Salvataggio...',
+  'Save': 'Salva',
   // Emotion selector
   'How do you feel today?': 'Come ti senti oggi?',
   'Select the emoji that best represents how you feel today:': 'Seleziona l\'emoticon che rappresenta meglio come ti senti oggi:'

--- a/pages/admin/create-dictionary.tsx
+++ b/pages/admin/create-dictionary.tsx
@@ -1,0 +1,93 @@
+import Page from '@/components/page'
+import Section from '@/components/section'
+import dynamic from 'next/dynamic'
+import { Trans, useLingui } from '@lingui/react'
+import { useState, useEffect } from 'react'
+import { useAuth } from '@/lib/auth-context'
+import { useRouter } from 'next/router'
+
+const RichTextEditor = dynamic(() => import('@/components/RichTextEditor'), { ssr: false })
+
+export default function CreateDictionary() {
+  const { user, isLoggedIn } = useAuth()
+  const router = useRouter()
+  const { i18n } = useLingui()
+  const [term, setTerm] = useState('')
+  const [definition, setDefinition] = useState('')
+  const [saving, setSaving] = useState(false)
+
+  useEffect(() => {
+    if (!isLoggedIn) {
+      router.push('/login')
+      return
+    }
+    if (user && !user.isAdmin) {
+      router.push('/')
+    }
+  }, [isLoggedIn, user, router])
+
+  const saveEntry = async () => {
+    if (!term.trim() || !definition.trim()) {
+      alert(i18n._('Please provide term and definition'))
+      return
+    }
+    setSaving(true)
+    const res = await fetch('/api/vocabulary', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ term, definition })
+    })
+    const data = await res.json()
+    if (res.ok) {
+      alert(i18n._('Saved'))
+      setTerm('')
+      setDefinition('')
+    } else {
+      alert(data.error || 'Error')
+    }
+    setSaving(false)
+  }
+
+  if (!isLoggedIn || !user?.isAdmin) {
+    return (
+      <Page title='Create Dictionary'>
+        <Section>
+          <p className='text-center text-zinc-600 dark:text-zinc-400'>
+            <Trans id='Access denied' />
+          </p>
+        </Section>
+      </Page>
+    )
+  }
+
+  return (
+    <Page title='Create Dictionary'>
+      <Section>
+        <h1 className='text-3xl font-bold mb-6 text-zinc-800 dark:text-zinc-200'>
+          <Trans id='Create dictionary entry' />
+        </h1>
+        <div className='mb-4'>
+          <input
+            type='text'
+            value={term}
+            onChange={(e) => setTerm(e.target.value)}
+            placeholder={i18n._('Word')}
+            className='w-full p-3 border border-zinc-300 dark:border-zinc-600 rounded-lg'
+          />
+        </div>
+        <RichTextEditor
+          value={definition}
+          onChange={setDefinition}
+          placeholder={i18n._('Definition')}
+        />
+        <button
+          onClick={saveEntry}
+          disabled={saving}
+          className='mt-4 px-6 py-3 bg-blue-500 text-white rounded-lg hover:bg-blue-600 disabled:opacity-50'
+        >
+          {saving ? i18n._('Saving...') : i18n._('Save')}
+        </button>
+      </Section>
+    </Page>
+  )
+}

--- a/pages/api/vocabulary/index.ts
+++ b/pages/api/vocabulary/index.ts
@@ -1,0 +1,43 @@
+import { NextApiRequest, NextApiResponse } from 'next'
+import { prisma } from '@/lib/prisma'
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const userId = req.cookies.userId
+  if (!userId) return res.status(401).json({ error: 'Not authenticated' })
+
+  if (req.method === 'GET') {
+    const q = typeof req.query.q === 'string' ? req.query.q : ''
+    const entries = await prisma.vocabularyEntry.findMany({
+      where: {
+        term: {
+          contains: q,
+          mode: 'insensitive'
+        }
+      },
+      orderBy: { term: 'asc' }
+    })
+    return res.status(200).json({ entries })
+  }
+
+  if (req.method === 'POST') {
+    const user = await prisma.user.findUnique({ where: { id: userId } })
+    if (!user || !user.isAdmin) {
+      return res.status(403).json({ error: 'Accesso negato' })
+    }
+
+    const { term, definition } = req.body
+    if (!term || !definition) {
+      return res.status(400).json({ error: 'Termine e definizione richiesti' })
+    }
+
+    try {
+      const entry = await prisma.vocabularyEntry.create({ data: { term, definition } })
+      return res.status(200).json({ entry })
+    } catch (error) {
+      console.error('Error creating entry:', error)
+      return res.status(500).json({ error: 'Errore durante la creazione' })
+    }
+  }
+
+  return res.status(405).json({ error: 'Method not allowed' })
+}

--- a/pages/vocabulary.tsx
+++ b/pages/vocabulary.tsx
@@ -1,0 +1,93 @@
+import Page from '@/components/page'
+import Section from '@/components/section'
+import { Trans, useLingui } from '@lingui/react'
+import { useState, useEffect } from 'react'
+import { useAuth } from '@/lib/auth-context'
+import { useRouter } from 'next/router'
+
+interface Entry {
+  id: string
+  term: string
+  definition: string
+}
+
+export default function Vocabulary() {
+  const { isLoggedIn } = useAuth()
+  const router = useRouter()
+  const { i18n } = useLingui()
+  const [entries, setEntries] = useState<Entry[]>([])
+  const [search, setSearch] = useState('')
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    if (!isLoggedIn) {
+      router.push('/login')
+      return
+    }
+    loadEntries('')
+  }, [isLoggedIn, router])
+
+  const loadEntries = async (q: string) => {
+    setLoading(true)
+    const res = await fetch('/api/vocabulary?q=' + encodeURIComponent(q))
+    if (res.ok) {
+      const data = await res.json()
+      setEntries(data.entries)
+    }
+    setLoading(false)
+  }
+
+  const handleSearch = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    loadEntries(search)
+  }
+
+  if (!isLoggedIn) {
+    return (
+      <Page title='Vocabulary'>
+        <Section>
+          <p className='text-center text-zinc-600 dark:text-zinc-400'>Loading...</p>
+        </Section>
+      </Page>
+    )
+  }
+
+  return (
+    <Page title='Vocabulary'>
+      <Section>
+        <h1 className='text-3xl font-bold mb-4 text-zinc-800 dark:text-zinc-200'>
+          <Trans id='Vocabolario Psicologico' />
+        </h1>
+        <p className='text-zinc-600 dark:text-zinc-400 mb-6'>
+          <Trans id='A glossary of relevant psychological terms' />
+        </p>
+        <form onSubmit={handleSearch} className='mb-6'>
+          <input
+            type='text'
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder={i18n._('Search')}
+            className='w-full p-3 border border-zinc-300 dark:border-zinc-600 rounded-lg'
+          />
+        </form>
+        {loading ? (
+          <p className='text-zinc-600 dark:text-zinc-400'>Loading...</p>
+        ) : (
+          <div className='space-y-6'>
+            {entries.map((entry) => (
+              <div key={entry.id} className='bg-white dark:bg-zinc-800 p-4 rounded-lg shadow'>
+                <h3 className='text-xl font-semibold mb-2 text-zinc-800 dark:text-zinc-200'>
+                  {entry.term}
+                </h3>
+                <div
+                  className='prose dark:prose-invert'
+                  dangerouslySetInnerHTML={{ __html: entry.definition }}
+                />
+              </div>
+            ))}
+          </div>
+        )}
+      </Section>
+    </Page>
+  )
+}

--- a/prisma/migrations/20250726233350_add_vocabulary_entry/migration.sql
+++ b/prisma/migrations/20250726233350_add_vocabulary_entry/migration.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS "VocabularyEntry" (
+  "id" TEXT NOT NULL,
+  "term" TEXT NOT NULL,
+  "definition" TEXT NOT NULL,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "VocabularyEntry_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "VocabularyEntry_term_key" ON "VocabularyEntry"("term");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -45,3 +45,11 @@ model Message {
 
   @@index([userId, createdAt])
 }
+
+model VocabularyEntry {
+  id         String   @id @default(cuid())
+  term       String   @unique
+  definition String
+  createdAt  DateTime @default(now())
+  updatedAt  DateTime @updatedAt
+}


### PR DESCRIPTION
## Summary
- add `VocabularyEntry` model and migration
- create vocabulary API with admin POST support
- add protected vocabulary page with search
- allow admins to create dictionary entries with rich text editor
- link admin dictionary page in profile menu
- update translations

## Testing
- `npx prisma generate` *(fails: 403 Forbidden for binaries)*
- `npm install` *(fails: prisma generate error 403)*


------
https://chatgpt.com/codex/tasks/task_e_6885652869c8832fb79ec9c50fcae5d5